### PR TITLE
docs: Remove ./ prefix from command examples in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,28 +93,28 @@ golangci-lint run
 ### Basic Usage
 ```bash
 # Connect to filesystem server (command transport)
-./mcp-server-dump npx @modelcontextprotocol/server-filesystem /Users/username/Documents
+mcp-server-dump npx @modelcontextprotocol/server-filesystem /Users/username/Documents
 
 # Connect to custom Node.js server
-./mcp-server-dump node server.js --port 3000
+mcp-server-dump node server.js --port 3000
 
 # Connect via SSE transport with headers
-./mcp-server-dump -t sse --endpoint "http://localhost:3001/sse" -H "Authorization:Bearer token"
+mcp-server-dump -t sse --endpoint "http://localhost:3001/sse" -H "Authorization:Bearer token"
 
 # Connect via streamable transport
-./mcp-server-dump -t streamable --endpoint "http://localhost:3001/stream"
+mcp-server-dump -t streamable --endpoint "http://localhost:3001/stream"
 
 # Disable table of contents in markdown output
-./mcp-server-dump --no-toc node server.js
+mcp-server-dump --no-toc node server.js
 
 # Generate HTML output
-./mcp-server-dump -f html node server.js
+mcp-server-dump -f html node server.js
 
 # Generate PDF output (requires output file)
-./mcp-server-dump -f pdf -o server-docs.pdf node server.js
+mcp-server-dump -f pdf -o server-docs.pdf node server.js
 
 # Output to JSON file
-./mcp-server-dump -f json -o output.json python mcp_server.py
+mcp-server-dump -f json -o output.json python mcp_server.py
 ```
 
 ### Development Testing
@@ -205,10 +205,10 @@ internal/
 ### Debug Commands
 ```bash
 # Check if binary works
-./mcp-server-dump -h
+mcp-server-dump -h
 
 # Test with verbose output
-./mcp-server-dump -v node server.js 2>&1 | tee debug.log
+mcp-server-dump -v node server.js 2>&1 | tee debug.log
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -70,80 +70,80 @@ Download the latest release from the [releases page](https://github.com/spandigi
 
 ```bash
 # Connect to a Node.js MCP server (default command transport)
-./mcp-server-dump node server.js
+mcp-server-dump node server.js
 
 # Connect to a Python MCP server with arguments
-./mcp-server-dump python server.py --config config.json
+mcp-server-dump python server.py --config config.json
 
 # Connect to an NPX package
-./mcp-server-dump npx @modelcontextprotocol/server-filesystem /path/to/directory
+mcp-server-dump npx @modelcontextprotocol/server-filesystem /path/to/directory
 
 # Connect to a UVX package (Python equivalent of npx)
-./mcp-server-dump uvx mcp-server-sqlite --db-path /path/to/database.db
+mcp-server-dump uvx mcp-server-sqlite --db-path /path/to/database.db
 
 # Run a Go MCP server directly
-./mcp-server-dump go run github.com/example/mcp-server@latest --example-argument=something
+mcp-server-dump go run github.com/example/mcp-server@latest --example-argument=something
 
 # Connect to a streamable HTTP transport server
-./mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream"
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream"
 
 # Connect to a streamable HTTP transport server (alternative endpoint)
-./mcp-server-dump --transport=streamable --endpoint="http://localhost:8080/mcp"
+mcp-server-dump --transport=streamable --endpoint="http://localhost:8080/mcp"
 ```
 
 ### Transport Options
 
 ```bash
 # Command transport (default) - runs server as subprocess
-./mcp-server-dump --transport=command node server.js
-./mcp-server-dump --transport=command --server-command="python server.py --arg value"
+mcp-server-dump --transport=command node server.js
+mcp-server-dump --transport=command --server-command="python server.py --arg value"
 
 # Streamable transport - connects to HTTP streamable endpoint
-./mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream"
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream"
 
 # Configure HTTP timeout for web transports
-./mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" --timeout=60s
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" --timeout=60s
 
 # Add custom HTTP headers for authentication or other purposes
-./mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" \
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" \
   -H "Authorization:Bearer your-token-here" \
   -H "X-API-Key:your-api-key"
 
 # Disable table of contents in markdown output
-./mcp-server-dump --no-toc node server.js
+mcp-server-dump --no-toc node server.js
 
 # Generate HTML output from markdown
-./mcp-server-dump -f html node server.js
+mcp-server-dump -f html node server.js
 
 # HTML output without table of contents
-./mcp-server-dump -f html --no-toc node server.js
+mcp-server-dump -f html --no-toc node server.js
 
 # Generate PDF output (requires output file)
-./mcp-server-dump -f pdf -o server-docs.pdf node server.js
+mcp-server-dump -f pdf -o server-docs.pdf node server.js
 
 # PDF output without table of contents
-./mcp-server-dump -f pdf --no-toc -o server-docs.pdf node server.js
+mcp-server-dump -f pdf --no-toc -o server-docs.pdf node server.js
 ```
 
 ### Output Options
 
 ```bash
 # Output to file (Markdown by default)
-./mcp-server-dump -o server-docs.md node server.js
+mcp-server-dump -o server-docs.md node server.js
 
 # JSON output
-./mcp-server-dump -f json node server.js
+mcp-server-dump -f json node server.js
 
 # HTML output
-./mcp-server-dump -f html node server.js
+mcp-server-dump -f html node server.js
 
 # PDF output (requires output file)
-./mcp-server-dump -f pdf -o server-docs.pdf node server.js
+mcp-server-dump -f pdf -o server-docs.pdf node server.js
 
 # Output to file (any format)
-./mcp-server-dump -f json -o server-info.json python server.py
-./mcp-server-dump -f html -o server-docs.html python server.py
-./mcp-server-dump -f pdf -o server-docs.pdf python server.py
+mcp-server-dump -f json -o server-info.json python server.py
+mcp-server-dump -f html -o server-docs.html python server.py
+mcp-server-dump -f pdf -o server-docs.pdf python server.py
 ```
 
 ### Frontmatter Support
@@ -152,10 +152,10 @@ Generate YAML, TOML, or JSON frontmatter in markdown output for integration with
 
 ```bash
 # Basic frontmatter (YAML by default)
-./mcp-server-dump --frontmatter node server.js
+mcp-server-dump --frontmatter node server.js
 
 # With custom metadata fields
-./mcp-server-dump --frontmatter \
+mcp-server-dump --frontmatter \
   -M "author:joe.bloggs@company.com" \
   -M "status:draft" \
   -M "team:engineering" \
@@ -163,13 +163,13 @@ Generate YAML, TOML, or JSON frontmatter in markdown output for integration with
   node server.js
 
 # TOML format frontmatter
-./mcp-server-dump --frontmatter --frontmatter-format=toml \
+mcp-server-dump --frontmatter --frontmatter-format=toml \
   -M "author:jane.doe@example.org" \
   -M "reviewed:false" \
   python server.py
 
 # JSON format frontmatter
-./mcp-server-dump --frontmatter --frontmatter-format=json \
+mcp-server-dump --frontmatter --frontmatter-format=json \
   -M "build_number:42" \
   -M "environment:production" \
   npx @modelcontextprotocol/server-filesystem /path
@@ -253,13 +253,13 @@ The following features are deprecated and included only for backward compatibili
 
 ```bash
 # SSE transport - connects to HTTP Server-Sent Events endpoint
-./mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse"
+mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse"
 
 # Configure HTTP timeout for SSE transport
-./mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse" --timeout=60s
+mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse" --timeout=60s
 
 # Add custom HTTP headers for SSE transport
-./mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse" \
+mcp-server-dump --transport=sse --endpoint="http://localhost:3001/sse" \
   -H "Authorization:Bearer your-token-here" \
   -H "X-API-Key:your-api-key"
 ```


### PR DESCRIPTION
## Summary

Removes the `./` prefix from all command examples in README.md to reflect that users will have the tool installed in their PATH.

## Changes

- Updated all command examples from `./mcp-server-dump` to `mcp-server-dump`
- Affects 31 command examples throughout the documentation

## Rationale

Since users will typically install mcp-server-dump via:
- **Homebrew**: `brew install spandigital/homebrew-tap/mcp-server-dump`
- **Go install**: `go install github.com/spandigital/mcp-server-dump/cmd/mcp-server-dump@latest`  
- **Pre-built binaries**: Installed to system PATH

The tool will be available as `mcp-server-dump` in their PATH, making the `./` prefix unnecessary and potentially confusing.

## Impact

- **User Experience**: Cleaner, more standard command examples
- **Documentation**: Matches typical CLI tool documentation patterns
- **Installation Methods**: Better reflects how users actually install and use the tool

This change makes the documentation more user-friendly and consistent with standard CLI tool conventions.