### PR TITLE
fix: Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,6 +7,9 @@ on:
       - 'action.yml'
       - '.github/workflows/test-action.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-scoop.yml
+++ b/.github/workflows/test-scoop.yml
@@ -9,6 +9,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-scoop:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- Addresses 5 CodeQL security scanning alerts by adding explicit permissions blocks to GitHub Actions workflows
- Follows the principle of least privilege by limiting GITHUB_TOKEN permissions to only what's needed
- Prevents potential security issues from overly permissive default tokens

## Changes
- Add `permissions: contents: read` to `.github/workflows/ci.yml` (fixes alerts #1, #2, #3)
- Add `permissions: contents: read` to `.github/workflows/test-action.yml` (fixes alert #4)  
- Add `permissions: contents: read` to `.github/workflows/test-scoop.yml` (fixes alert #5)

## Security Impact
These changes improve security by:
- Explicitly limiting the GITHUB_TOKEN permissions in each workflow
- Following GitHub security best practices recommended by CodeQL
- Preventing accidental write operations from workflows that only need read access

## Testing
- All three workflows only perform read operations (checkout, testing, linting)
- The existing `release.yml` already has proper write permissions for creating releases
- Changes are minimal and only add security constraints

Fixes GitHub code scanning alerts: https://github.com/SPANDigital/mcp-server-dump/security/code-scanning