### PR TITLE
style: Apply gofumpt formatting

### DIFF
--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -122,7 +122,7 @@ func parseContextFile(data []byte, cleanPath string) (config ContextConfig, err 
 	default:
 		err = fmt.Errorf("unsupported file format: %s (supported: .yaml, .yml, .json)", ext)
 	}
-	return
+	return config, err
 }
 
 // mergeContextData merges the parsed context data into the current configuration


### PR DESCRIPTION
## Summary
- Applied gofumpt formatting to the codebase
- Fixed bare return statement to explicitly return named values in `parseContextFile`

## Test plan
- [x] Run `gofumpt -w ./cmd/mcp-server-dump/ ./internal/`
- [x] Run `golangci-lint run` - no issues found
- [x] Changes are minimal and safe (only formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)