### PR TITLE
fix: Update fpdf import path from github.com to codeberg.org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ golangci-lint run
 - `github.com/modelcontextprotocol/go-sdk` - Official MCP Go SDK for client/server communication
 - `github.com/alecthomas/kong` - Command line argument parsing library
 - `github.com/yuin/goldmark` - Markdown to HTML converter with GitHub Flavored Markdown support
-- `github.com/go-pdf/fpdf` - Pure Go PDF generation library with bookmark support
+- `codeberg.org/go-pdf/fpdf` - Pure Go PDF generation library with bookmark support
 - `gopkg.in/yaml.v2` - YAML parsing and generation for frontmatter and context file support
 
 ### Development Tools

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/spandigital/mcp-server-dump
 go 1.25.0
 
 require (
+	codeberg.org/go-pdf/fpdf v0.11.1
 	github.com/alecthomas/kong v1.12.1
-	github.com/go-pdf/fpdf v0.9.0
 	github.com/modelcontextprotocol/go-sdk v0.7.0
 	github.com/yuin/goldmark v1.7.13
 	golang.org/x/text v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
+codeberg.org/go-pdf/fpdf v0.11.1 h1:U8+coOTDVLxHIXZgGvkfQEi/q0hYHYvEHFuGNX2GzGs=
+codeberg.org/go-pdf/fpdf v0.11.1/go.mod h1:Y0DGRAdZ0OmnZPvjbMp/1bYxmIPxm0ws4tfoPOc4LjU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.12.1 h1:iq6aMJDcFYP9uFrLdsiZQ2ZMmcshduyGv4Pek0MQPW0=
 github.com/alecthomas/kong v1.12.1/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
-github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=

--- a/internal/formatter/pdf.go
+++ b/internal/formatter/pdf.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-pdf/fpdf"
+	"codeberg.org/go-pdf/fpdf"
 
 	"github.com/spandigital/mcp-server-dump/internal/model"
 )


### PR DESCRIPTION
Fixes #28

## Changes
- Updated import from `github.com/go-pdf/fpdf` to `codeberg.org/go-pdf/fpdf`
- Upgraded to v0.11.1 (latest version with correct module path)
- Updated CLAUDE.md documentation to reflect new import path

## Testing
- ✅ Build succeeds
- ✅ PDF generation tested and working
- ✅ All imports updated

## Notes
The issue was that v0.9.0 still declared its module path as `github.com/go-pdf/fpdf`. Version v0.11.1 has the correct `codeberg.org/go-pdf/fpdf` module declaration, so we upgraded to that version.