### PR TITLE
fix: Remove JSON output format from Hugo templates

### DIFF
--- a/internal/app/templates/hugo/hugo.yml.tmpl
+++ b/internal/app/templates/hugo/hugo.yml.tmpl
@@ -209,7 +209,7 @@ security:
 
 # Output formats (enhanced for documentation)
 outputs:
-  home: ["HTML", "RSS", "JSON"]
+  home: ["HTML", "RSS"]
   page: ["HTML"]
   section: ["HTML", "RSS"]
 

--- a/internal/formatter/test_templates/hugo/hugo.yml.tmpl
+++ b/internal/formatter/test_templates/hugo/hugo.yml.tmpl
@@ -209,7 +209,7 @@ security:
 
 # Output formats (enhanced for documentation)
 outputs:
-  home: ["HTML", "RSS", "JSON"]
+  home: ["HTML", "RSS"]
   page: ["HTML"]
   section: ["HTML", "RSS"]
 


### PR DESCRIPTION
## Problem
When following the Hugo documentation instructions, users get this error:
```
found no layout file for "json" for kind "home": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
```

## Root Cause
The Hugo configuration templates specify JSON as an output format in line 212:
```yaml
outputs:
  home: ["HTML", "RSS", "JSON"]
```

However, the Hextra theme doesn't provide JSON layout templates, causing Hugo builds to fail.

## Solution
Removed JSON from the output formats in both template files:
- `internal/app/templates/hugo/hugo.yml.tmpl`
- `internal/formatter/test_templates/hugo/hugo.yml.tmpl`

## Why this is the right fix
- The Hextra theme doesn't include JSON templates
- JSON output isn't needed for documentation sites
- HTML and RSS are sufficient for documentation purposes

## Testing
✅ Integration tests pass
✅ Generated Hugo site no longer includes JSON in outputs
✅ Hugo build succeeds without errors