### PR TITLE
chore: upgrade MCP Go SDK to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	codeberg.org/go-pdf/fpdf v0.11.1
 	github.com/alecthomas/kong v1.12.1
-	github.com/modelcontextprotocol/go-sdk v0.7.0
+	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/yuin/goldmark v1.7.13
 	golang.org/x/text v0.29.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIy
 github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/modelcontextprotocol/go-sdk v0.7.0 h1:XEQfn3bDx2cAdSUKty3tYEMll5dtRgBUDX88Q65fai0=
-github.com/modelcontextprotocol/go-sdk v0.7.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
+github.com/modelcontextprotocol/go-sdk v0.8.0 h1:jdsBtGzBLY287WKSIjYovOXAqtJkP+HtFQFKrZd4a6c=
+github.com/modelcontextprotocol/go-sdk v0.8.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=


### PR DESCRIPTION
## Summary
Upgrades the MCP Go SDK from v0.7.0 to v0.8.0, released on September 26, 2025.

## Changes in v0.8.0
- **JSON schema fields relaxed to type `any`**: Decouples the SDK from the `github.com/google/jsonschema-go/jsonschema` package
- **Removed error code constants**: Some functionally inaccessible error code constants were removed
- **API audit preparation**: Prepares for upcoming v1.0.0 release with backwards compatibility guarantees

## Compatibility Assessment
✅ **No breaking changes affect our codebase**:
- We already use `any` types for JSON schema fields in our model structs
- We don't use any MCP error code constants
- All imports remain the same (`github.com/modelcontextprotocol/go-sdk/mcp`)

## Testing
- ✅ Build succeeds
- ✅ All tests pass  
- ✅ CLI functionality verified
- ✅ No code changes required

## References
- [v0.8.0 Release Notes](https://github.com/modelcontextprotocol/go-sdk/releases/tag/v0.8.0)
- [MCP Go SDK Repository](https://github.com/modelcontextprotocol/go-sdk)

This upgrade keeps us current with the latest SDK release as it approaches v1.0.0 stability.