### PR TITLE
feat: make enterprise_key optional via CLI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ mcp-server-dump -f hugo -o hugo-docs node server.js
 mcp-server-dump -f hugo -o hugo-docs \
   --hugo-base-url="https://docs.example.com" \
   --hugo-language-code="en-us" \
+  --hugo-enterprise-key="my-custom-key" \
   node server.js
 
 # Output to file (any format)
@@ -443,10 +444,11 @@ Flags:
       --no-prompts           Skip scanning prompts from the MCP server
 
 Hugo-specific options (only used when format=hugo):
-      --hugo-base-url=STRING        Base URL for Hugo site (e.g., https://example.com)
-      --hugo-language-code=STRING   Language code for Hugo site (default: en-us)
+      --hugo-base-url=STRING           Base URL for Hugo site (e.g., https://example.com)
+      --hugo-language-code=STRING      Language code for Hugo site (default: en-us)
+      --hugo-enterprise-key=STRING     Enterprise key for Presidium configuration (optional, uses server name if not specified)
       --custom-initialisms=STRING,...
-                                    Additional technical initialisms to recognize for human-readable headings
+                                       Additional technical initialisms to recognize for human-readable headings
 ```
 
 ## GitHub Action

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,9 @@ inputs:
     description: 'Language code for Hugo site (e.g., en, en-US, zh-Hans, pt-BR)'
     required: false
     default: 'en-us'
+  hugo-enterprise-key:
+    description: 'Enterprise key for Presidium configuration (optional, uses server name if not specified)'
+    required: false
   hugo-theme:
     description: '[DEPRECATED] No longer supported with Presidium layouts. Hugo now uses Presidium modules automatically.'
     required: false
@@ -284,6 +287,12 @@ runs:
             HUGO_LANG_CODE="${{ inputs.hugo-language-code }}"
             if [ -n "${HUGO_LANG_CODE}" ] && [ "${HUGO_LANG_CODE}" != "en-us" ]; then
                 CMD_ARGS+=("--hugo-language-code" "${HUGO_LANG_CODE}")
+            fi
+
+            # Hugo enterprise key (optional)
+            HUGO_ENTERPRISE_KEY="${{ inputs.hugo-enterprise-key }}"
+            if [ -n "${HUGO_ENTERPRISE_KEY}" ]; then
+                CMD_ARGS+=("--hugo-enterprise-key" "${HUGO_ENTERPRISE_KEY}")
             fi
 
             # Deprecated Hugo flags - show warnings but do not pass to command

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -41,8 +41,9 @@ type CLI struct {
 
 	// Hugo-specific options (only used when format=hugo)
 	// Uses Hugo Modules with Presidium layouts
-	HugoBaseURL      string `kong:"help='Base URL for Hugo site (e.g., https://example.com)'"`
-	HugoLanguageCode string `kong:"help='Language code for Hugo site (default: en-us)'"`
+	HugoBaseURL       string `kong:"help='Base URL for Hugo site (e.g., https://example.com)'"`
+	HugoLanguageCode  string `kong:"help='Language code for Hugo site (default: en-us)'"`
+	HugoEnterpriseKey string `kong:"help='Enterprise key for Presidium configuration (optional, uses server name if not specified)'"`
 
 	// Deprecated Hugo flags (maintained for backward compatibility)
 	HugoTheme           string `kong:"help='[DEPRECATED] No longer supported with Presidium layouts',hidden"`

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -260,8 +260,9 @@ func formatHugo(info *model.ServerInfo, cli *CLI) ([]byte, error) {
 	enableFrontmatter := cli.Frontmatter || cli.Format == "hugo"
 
 	hugoConfig := &formatter.HugoConfig{
-		BaseURL:      cli.HugoBaseURL,
-		LanguageCode: cli.HugoLanguageCode,
+		BaseURL:       cli.HugoBaseURL,
+		LanguageCode:  cli.HugoLanguageCode,
+		EnterpriseKey: cli.HugoEnterpriseKey,
 	}
 
 	warnDeprecatedHugoFlags(cli)

--- a/internal/app/templates/hugo/hugo.yml.tmpl
+++ b/internal/app/templates/hugo/hugo.yml.tmpl
@@ -80,7 +80,11 @@ outputs:
 
 # Site parameters (Presidium configuration)
 params:
+  {{- if .HugoConfig.EnterpriseKey }}
+  enterprise_key: {{ .HugoConfig.EnterpriseKey }}
+  {{- else }}
   enterprise_key: {{ .Name }}
+  {{- end }}
   frontmatter:
     - key: author
       type: email

--- a/internal/formatter/hugo.go
+++ b/internal/formatter/hugo.go
@@ -20,8 +20,9 @@ import (
 
 // HugoConfig holds Hugo-specific configuration options
 type HugoConfig struct {
-	BaseURL      string
-	LanguageCode string
+	BaseURL       string
+	LanguageCode  string
+	EnterpriseKey string // Optional Presidium enterprise key
 }
 
 // Validate validates the Hugo configuration and returns any errors found

--- a/internal/formatter/test_templates/hugo/hugo.yml.tmpl
+++ b/internal/formatter/test_templates/hugo/hugo.yml.tmpl
@@ -80,7 +80,11 @@ outputs:
 
 # Site parameters (Presidium configuration)
 params:
+  {{- if .HugoConfig.EnterpriseKey }}
+  enterprise_key: {{ .HugoConfig.EnterpriseKey }}
+  {{- else }}
   enterprise_key: {{ .Name }}
+  {{- end }}
   frontmatter:
     - key: author
       type: email


### PR DESCRIPTION
## Summary
Makes the Presidium `enterprise_key` parameter optionally configurable via CLI and GitHub Action, addressing code review feedback from PR #45.

## Changes

### CLI Enhancement
- Added `--hugo-enterprise-key` flag to configure Presidium enterprise key
- Optional parameter that defaults to server name if not specified
- Maintains backward compatibility with existing behavior

### Configuration
- Updated `HugoConfig` struct to include `EnterpriseKey` field
- Modified Hugo templates to conditionally use custom or default enterprise key
- Templates fall back to server name when enterprise key not provided

### GitHub Action Parity
- Added `hugo-enterprise-key` input parameter to GitHub Action
- Processes and passes enterprise key to CLI command
- Maintains complete feature parity between CLI and Action

### Documentation
- Updated README.md with new flag examples
- Added CLI options reference for `--hugo-enterprise-key`
- Shows both default and custom usage patterns

## Motivation
Code review of PR #45 identified that `enterprise_key` was hardcoded to use the server name. This change provides flexibility for organizations that need custom enterprise keys while maintaining the simple default behavior for most users.

## Usage Examples

### CLI - Default Behavior
```bash
# Uses server name as enterprise_key
mcp-server-dump -f hugo -o docs node server.js
```

### CLI - Custom Enterprise Key
```bash
# Uses custom enterprise_key
mcp-server-dump -f hugo -o docs \
  --hugo-enterprise-key="my-org-key" \
  node server.js
```

### GitHub Action
```yaml
- uses: spandigital/mcp-server-dump@main
  with:
    format: hugo
    output-file: hugo-docs
    hugo-enterprise-key: 'my-org-key'
    server-command: 'node server.js'
```

## Testing
- ✅ All unit tests pass
- ✅ Integration tests pass
- ✅ Linting clean (0 issues)
- ✅ Backward compatible (no breaking changes)
- ✅ Existing tests work without modifications

## References
- PR #45: Switch from Hextra to Presidium layouts
- Issue #48: Document Presidium configuration and best practices
- Code review comment: https://github.com/SPANDigital/mcp-server-dump/pull/45#issuecomment-3351020224

## Notes
This PR replaces #50 with a clean branch that doesn't have merge conflicts after PR #45 was merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)