### PR TITLE
feat: make author field strict requirement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ mcp-server-dump -f hugo -o hugo-docs \
   --hugo-base-url="https://docs.example.com" \
   --hugo-language-code="en-us" \
   --hugo-enterprise-key="my-custom-key" \
+  --hugo-author-strict \
   node server.js
 
 # Output to file (any format)
@@ -447,6 +448,7 @@ Hugo-specific options (only used when format=hugo):
       --hugo-base-url=STRING           Base URL for Hugo site (e.g., https://example.com)
       --hugo-language-code=STRING      Language code for Hugo site (default: en-us)
       --hugo-enterprise-key=STRING     Enterprise key for Presidium configuration (optional, uses server name if not specified)
+      --hugo-author-strict             Require author field in frontmatter (default: false)
       --custom-initialisms=STRING,...
                                        Additional technical initialisms to recognize for human-readable headings
 ```

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
   hugo-enterprise-key:
     description: 'Enterprise key for Presidium configuration (optional, uses server name if not specified)'
     required: false
+  hugo-author-strict:
+    description: 'Require author field in frontmatter (default: false)'
+    required: false
+    default: 'false'
   hugo-theme:
     description: '[DEPRECATED] No longer supported with Presidium layouts. Hugo now uses Presidium modules automatically.'
     required: false
@@ -293,6 +297,12 @@ runs:
             HUGO_ENTERPRISE_KEY="${{ inputs.hugo-enterprise-key }}"
             if [ -n "${HUGO_ENTERPRISE_KEY}" ]; then
                 CMD_ARGS+=("--hugo-enterprise-key" "${HUGO_ENTERPRISE_KEY}")
+            fi
+
+            # Hugo author strict (optional, default: false)
+            HUGO_AUTHOR_STRICT="${{ inputs.hugo-author-strict }}"
+            if [ "${HUGO_AUTHOR_STRICT}" = "true" ]; then
+                CMD_ARGS+=("--hugo-author-strict")
             fi
 
             # Deprecated Hugo flags - show warnings but do not pass to command

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -44,6 +44,7 @@ type CLI struct {
 	HugoBaseURL       string `kong:"help='Base URL for Hugo site (e.g., https://example.com)'"`
 	HugoLanguageCode  string `kong:"help='Language code for Hugo site (default: en-us)'"`
 	HugoEnterpriseKey string `kong:"help='Enterprise key for Presidium configuration (optional, uses server name if not specified)'"`
+	HugoAuthorStrict  bool   `kong:"help='Require author field in frontmatter (default: false)'"`
 
 	// Deprecated Hugo flags (maintained for backward compatibility)
 	HugoTheme           string `kong:"help='[DEPRECATED] No longer supported with Presidium layouts',hidden"`

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -263,6 +263,7 @@ func formatHugo(info *model.ServerInfo, cli *CLI) ([]byte, error) {
 		BaseURL:       cli.HugoBaseURL,
 		LanguageCode:  cli.HugoLanguageCode,
 		EnterpriseKey: cli.HugoEnterpriseKey,
+		AuthorStrict:  cli.HugoAuthorStrict,
 	}
 
 	warnDeprecatedHugoFlags(cli)

--- a/internal/app/templates/hugo/hugo.yml.tmpl
+++ b/internal/app/templates/hugo/hugo.yml.tmpl
@@ -88,7 +88,7 @@ params:
   frontmatter:
     - key: author
       type: email
-      strict: true
+      strict: {{ .HugoConfig.AuthorStrict }}
     - key: title
       type: text
       strict: true

--- a/internal/formatter/hugo.go
+++ b/internal/formatter/hugo.go
@@ -23,6 +23,7 @@ type HugoConfig struct {
 	BaseURL       string
 	LanguageCode  string
 	EnterpriseKey string // Optional Presidium enterprise key
+	AuthorStrict  bool   // Whether to require author field in frontmatter (default: false)
 }
 
 // Validate validates the Hugo configuration and returns any errors found

--- a/internal/formatter/test_templates/hugo/hugo.yml.tmpl
+++ b/internal/formatter/test_templates/hugo/hugo.yml.tmpl
@@ -88,7 +88,7 @@ params:
   frontmatter:
     - key: author
       type: email
-      strict: true
+      strict: {{ .HugoConfig.AuthorStrict }}
     - key: title
       type: text
       strict: true


### PR DESCRIPTION
## Summary

Make the Presidium `author` field `strict` property configurable via CLI with a default of `false` (not required). This allows more flexibility in documentation generation while maintaining the option to enforce author metadata when needed.

## Changes

- ✅ Add `--hugo-author-strict` CLI flag (default: false)
- ✅ Add `hugo-author-strict` input to GitHub Action (default: false)
- ✅ Update `HugoConfig` struct with `AuthorStrict` field
- ✅ Update Hugo templates to use configurable strict value
- ✅ Update documentation with new flag

## Examples

**CLI Usage:**
```bash
# Default: author field not required
mcp-server-dump -f hugo -o hugo-docs node server.js

# Make author field required
mcp-server-dump -f hugo -o hugo-docs --hugo-author-strict node server.js
```

**GitHub Action Usage:**
```yaml
- name: Generate Hugo docs
  uses: spandigital/mcp-server-dump@v1
  with:
    format: hugo
    output-file: hugo-docs
    hugo-author-strict: true  # Make author required
```

## Backward Compatibility

✅ **Fully backward compatible** - Default is `false` (not required), which is more permissive than the previous hardcoded `true` value. This is an improvement for most use cases.

## Testing

- ✅ All tests pass
- ✅ Linter clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)