### PR TITLE
feat: humanize titles in generated Hugo content files

### DIFF
--- a/internal/app/templates/hugo/prompt.md.tmpl
+++ b/internal/app/templates/hugo/prompt.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 {{ if .Description }}{{ .Description }}{{ else }}*No description available*{{ end }}
 

--- a/internal/app/templates/hugo/prompt.md.tmpl
+++ b/internal/app/templates/hugo/prompt.md.tmpl
@@ -14,12 +14,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/app/templates/hugo/resource.md.tmpl
+++ b/internal/app/templates/hugo/resource.md.tmpl
@@ -13,12 +13,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/app/templates/hugo/resource.md.tmpl
+++ b/internal/app/templates/hugo/resource.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 **URI:** `{{ .URI }}`
 

--- a/internal/app/templates/hugo/tool.md.tmpl
+++ b/internal/app/templates/hugo/tool.md.tmpl
@@ -13,12 +13,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/app/templates/hugo/tool.md.tmpl
+++ b/internal/app/templates/hugo/tool.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 {{ if .Description }}{{ .Description }}{{ else }}*No description available*{{ end }}
 

--- a/internal/formatter/hugo.go
+++ b/internal/formatter/hugo.go
@@ -23,7 +23,6 @@ type HugoConfig struct {
 	BaseURL       string
 	LanguageCode  string
 	EnterpriseKey string // Optional Presidium enterprise key
-	AuthorStrict  bool   // Whether to require author field in frontmatter (default: false)
 }
 
 // Validate validates the Hugo configuration and returns any errors found

--- a/internal/formatter/hugo.go
+++ b/internal/formatter/hugo.go
@@ -23,6 +23,7 @@ type HugoConfig struct {
 	BaseURL       string
 	LanguageCode  string
 	EnterpriseKey string // Optional Presidium enterprise key
+	AuthorStrict  bool   // Whether to require author field in frontmatter (default: false)
 }
 
 // Validate validates the Hugo configuration and returns any errors found
@@ -351,7 +352,7 @@ func generateContentFile(dir string, data any, name, itemType string, weight int
 
 	// Prepare frontmatter fields
 	fields := make(map[string]any)
-	fields["title"] = name
+	fields["title"] = humanizeKeyWithCustomInitialisms(name, customInitialisms)
 	fields["date"] = generationTime.Format(time.RFC3339)
 	fields["draft"] = false
 	fields["weight"] = weight
@@ -380,6 +381,9 @@ func generateContentFile(dir string, data any, name, itemType string, weight int
 		"humanizeKey": func(key string) string {
 			return humanizeKeyWithCustomInitialisms(key, customInitialisms)
 		},
+		"humanize": func(name string) string {
+			return humanizeKeyWithCustomInitialisms(name, customInitialisms)
+		},
 	})
 
 	// Parse template from embedded filesystem - try test path first, then production path
@@ -395,6 +399,9 @@ func generateContentFile(dir string, data any, name, itemType string, weight int
 			"sortedKeys": getSortedKeys,
 			"humanizeKey": func(key string) string {
 				return humanizeKeyWithCustomInitialisms(key, customInitialisms)
+			},
+			"humanize": func(name string) string {
+				return humanizeKeyWithCustomInitialisms(name, customInitialisms)
 			},
 		})
 		tmpl, err = tmpl.ParseFS(templateFS, prodPath)

--- a/internal/formatter/hugo.go
+++ b/internal/formatter/hugo.go
@@ -351,11 +351,8 @@ func createHugoTemplateFuncMap(customInitialisms []string) template.FuncMap {
 		"json":       jsonIndent,
 		"contains":   strings.Contains,
 		"sortedKeys": getSortedKeys,
-		"humanizeKey": func(key string) string {
-			return humanizeKeyWithCustomInitialisms(key, customInitialisms)
-		},
-		"humanize": func(name string) string {
-			return humanizeKeyWithCustomInitialisms(name, customInitialisms)
+		"humanize": func(s string) string {
+			return humanizeKeyWithCustomInitialisms(s, customInitialisms)
 		},
 	}
 }

--- a/internal/formatter/hugo_modules_integration_test.go
+++ b/internal/formatter/hugo_modules_integration_test.go
@@ -215,7 +215,7 @@ func verifyToolContent(t *testing.T, contentDir string) {
 	toolStr := string(toolContent)
 	expectedContent := []string{
 		"---",
-		"title: example_tool",
+		"title: Example Tool",
 		"weight:",
 	}
 

--- a/internal/formatter/test_templates/hugo/prompt.md.tmpl
+++ b/internal/formatter/test_templates/hugo/prompt.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 {{ if .Description }}{{ .Description }}{{ else }}*No description available*{{ end }}
 

--- a/internal/formatter/test_templates/hugo/prompt.md.tmpl
+++ b/internal/formatter/test_templates/hugo/prompt.md.tmpl
@@ -14,12 +14,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/formatter/test_templates/hugo/resource.md.tmpl
+++ b/internal/formatter/test_templates/hugo/resource.md.tmpl
@@ -13,12 +13,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/formatter/test_templates/hugo/resource.md.tmpl
+++ b/internal/formatter/test_templates/hugo/resource.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 **URI:** `{{ .URI }}`
 

--- a/internal/formatter/test_templates/hugo/tool.md.tmpl
+++ b/internal/formatter/test_templates/hugo/tool.md.tmpl
@@ -13,12 +13,12 @@
 {{ range $key := sortedKeys .Context -}}
 {{ $value := index $.Context $key -}}
 {{ if contains $value "\n" -}}
-### {{ humanizeKey $key }}
+### {{ humanize $key }}
 
 {{ $value }}
 
 {{ else -}}
-**{{ humanizeKey $key }}:** {{ $value }}
+**{{ humanize $key }}:** {{ $value }}
 
 {{ end -}}
 {{ end -}}

--- a/internal/formatter/test_templates/hugo/tool.md.tmpl
+++ b/internal/formatter/test_templates/hugo/tool.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Name }}
+# {{ humanize .Name }}
 
 {{ if .Description }}{{ .Description }}{{ else }}*No description available*{{ end }}
 


### PR DESCRIPTION
## Summary

Apply human-readable formatting to tool/resource/prompt titles in both frontmatter and markdown headings. Uses the existing `humanizeKeyWithCustomInitialisms` function to handle camelCase, underscores, and technical initialisms properly.

## Examples

**Before:**
- Frontmatter: `title: get_api_key`
- Markdown: `# get_api_key`

**After:**
- Frontmatter: `title: Get API Key`
- Markdown: `# Get API Key`

**Transformation examples:**
- `get_api_key` → `Get API Key`
- `XMLHttpRequest` → `XML HTTP Request`
- `user_name` → `User Name`
- `example_tool` → `Example Tool`

## Changes

- ✅ Humanize frontmatter title field in `generateContentFile`
- ✅ Add `humanize` template function to FuncMap
- ✅ Update all Hugo templates (production and test) to use `{{ humanize .Name }}`
- ✅ Update test expectations to match humanized titles

## Benefits

- 📖 **Improved readability**: Human-friendly titles throughout Hugo site
- 🔤 **Technical accuracy**: Properly handles initialisms (API stays API, not Api)
- 🔧 **Existing support**: Works seamlessly with `--custom-initialisms` flag
- 📝 **Consistent formatting**: Same humanization used throughout the codebase

## Technical Details

The change leverages the existing `humanizeKeyWithCustomInitialisms` function which:
- Splits camelCase boundaries (`XMLHttpRequest` → `XML HTTP Request`)
- Replaces underscores with spaces (`user_name` → `User Name`)
- Preserves common technical initialisms (API, HTTP, JSON, SSH, etc.)
- Supports custom initialisms via CLI flag

## Testing

- ✅ All tests pass (including Hugo modules integration tests)
- ✅ Linter clean (0 issues)
- ✅ Test updated to expect humanized title: `"Example Tool"` instead of `"example_tool"`

## Backward Compatibility

⚠️ **Minor breaking change**: Generated title format changes from raw names to human-readable format. This only affects the visual presentation in Hugo sites, not functionality. Existing Hugo sites will need to be regenerated to pick up the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)