### PR TITLE
feat: Add tool calling capability to CLI and GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,16 @@ inputs:
   custom-initialisms:
     description: 'Additional technical initialisms to recognize for human-readable headings (comma-separated, e.g., API,CDN,JWT,CORP,ACME)'
     required: false
+  call-tool:
+    description: 'Call specific tool(s) by name (comma-separated for multiple tools, e.g., "get_weather,get_forecast")'
+    required: false
+  tool-args:
+    description: 'JSON arguments for tool calls (applies to all tools specified in call-tool)'
+    required: false
+  call-all-tools:
+    description: 'Call all available tools with empty/provided arguments for testing and documentation'
+    required: false
+    default: 'false'
 
 outputs:
   output-file:
@@ -329,6 +339,25 @@ runs:
             for initialism in "${PARSED_ITEMS[@]}"; do
                 CMD_ARGS+=("--custom-initialisms" "${initialism}")
             done
+        fi
+
+        # Add tool calling options if specified
+        if [ "${{ inputs.call-all-tools }}" = "true" ]; then
+            CMD_ARGS+=("--call-all-tools")
+            log "Tool Calling: Will call all available tools"
+        fi
+
+        if [ -n "${{ inputs.call-tool }}" ]; then
+            parse_comma_separated_values "${{ inputs.call-tool }}" "tool name"
+            for tool_name in "${PARSED_ITEMS[@]}"; do
+                CMD_ARGS+=("--call-tool" "${tool_name}")
+            done
+            log "Tool Calling: Will call ${#PARSED_ITEMS[@]} specific tool(s)"
+        fi
+
+        if [ -n "${{ inputs.tool-args }}" ]; then
+            CMD_ARGS+=("--tool-args" "${{ inputs.tool-args }}")
+            log "Tool Calling: Using custom arguments"
         fi
 
         # Add server command (this should be the last argument)

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -39,6 +39,11 @@ type CLI struct {
 	NoResources bool `kong:"help='Skip scanning resources from the MCP server'"`
 	NoPrompts   bool `kong:"help='Skip scanning prompts from the MCP server'"`
 
+	// Tool calling options
+	CallTool     []string `kong:"help='Call specific tool(s) by name, can be used multiple times'"`
+	ToolArgs     string   `kong:"help='JSON arguments for tool calls (applies to all --call-tool invocations)'"`
+	CallAllTools bool     `kong:"help='Call all available tools with empty arguments for testing'"`
+
 	// Hugo-specific options (only used when format=hugo)
 	// Uses Hugo Modules with Presidium layouts
 	HugoBaseURL       string `kong:"help='Base URL for Hugo site (e.g., https://example.com)'"`

--- a/internal/app/templates/base.md.tmpl
+++ b/internal/app/templates/base.md.tmpl
@@ -26,6 +26,12 @@
   - [{{.Name}}](#{{.Name | anchor}})
   {{- end}}
 {{- end}}
+{{- if .ToolCalls}}
+- [Tool Call Results](#tool-call-results)
+  {{- range .ToolCalls}}
+  - [{{.ToolName}}](#{{.ToolName | anchor}})
+  {{- end}}
+{{- end}}
 {{- end}}
 
 {{template "capabilities" .}}
@@ -40,4 +46,8 @@
 
 {{- if .Prompts}}
 {{template "prompts" .}}
+{{- end}}
+
+{{- if .ToolCalls}}
+{{template "tool_calls" .}}
 {{- end}}

--- a/internal/app/templates/tool_calls.md.tmpl
+++ b/internal/app/templates/tool_calls.md.tmpl
@@ -1,0 +1,40 @@
+{{- /* Template for tool call results section */ -}}
+## Tool Call Results
+
+{{- range .ToolCalls}}
+
+### {{.ToolName}}
+
+{{- if .Arguments}}
+**Arguments:**
+```json
+{{.Arguments | jsonIndent}}
+```
+{{- end}}
+
+{{- if .Error}}
+**Error:** {{.Error}}
+{{- else}}
+
+{{- if .Content}}
+**Content:**
+{{- range .Content}}
+{{- if .Text}}
+{{.Text}}
+{{- else}}
+```json
+{{. | jsonIndent}}
+```
+{{- end}}
+{{- end}}
+{{- end}}
+
+{{- if .StructuredContent}}
+**Structured Content:**
+```json
+{{.StructuredContent | jsonIndent}}
+```
+{{- end}}
+
+{{- end}}
+{{- end}}

--- a/internal/formatter/markdown.go
+++ b/internal/formatter/markdown.go
@@ -27,6 +27,7 @@ func FormatMarkdown(info *model.ServerInfo, includeTOC, includeFrontmatter bool,
 	tmpl := template.New("base.md.tmpl").Funcs(template.FuncMap{
 		"anchor":     anchorName,
 		"json":       jsonIndent,
+		"jsonIndent": jsonIndent,
 		"formatBool": formatBool,
 		"contains":   strings.Contains,
 		"humanizeKey": func(key string) string {

--- a/internal/model/server.go
+++ b/internal/model/server.go
@@ -8,6 +8,7 @@ type ServerInfo struct {
 	Tools        []Tool       `json:"tools"`
 	Resources    []Resource   `json:"resources"`
 	Prompts      []Prompt     `json:"prompts"`
+	ToolCalls    []ToolCall   `json:"toolCalls,omitempty"`
 }
 
 // Capabilities represents the capabilities of an MCP server
@@ -40,4 +41,13 @@ type Prompt struct {
 	Description string            `json:"description"`
 	Arguments   []any             `json:"arguments"`
 	Context     map[string]string `json:"context,omitempty"`
+}
+
+// ToolCall represents the result of calling an MCP tool
+type ToolCall struct {
+	ToolName          string `json:"toolName"`
+	Arguments         any    `json:"arguments,omitempty"`
+	Content           []any  `json:"content,omitempty"`
+	StructuredContent any    `json:"structuredContent,omitempty"`
+	Error             string `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive tool calling functionality to both the CLI tool and GitHub Action, enabling users to call MCP tools directly and include execution results in their documentation output.

## Features Added

### CLI Tool
- **`--call-tool <name>`** - Call specific tools by name (can be used multiple times)
- **`--tool-args <json>`** - Pass JSON arguments to tools
- **`--call-all-tools`** - Call all available tools for comprehensive testing

### GitHub Action
- **`call-tool`** input - Comma-separated tool names
- **`tool-args`** input - JSON arguments string
- **`call-all-tools`** input - Boolean flag for calling all tools

### Data Model
- New `ToolCall` struct to store execution results
- Captures tool name, arguments, content, structured content, and errors
- Added to `ServerInfo` for seamless integration

### Output Templates
- New `tool_calls.md.tmpl` template for rendering tool call results
- Updated `base.md.tmpl` to include tool calls section in TOC and content
- Added `jsonIndent` template function for pretty JSON formatting

### Documentation
- Updated README.md with CLI and GitHub Action usage examples
- Updated CLAUDE.md with architecture and implementation details
- Added comprehensive examples for various use cases

## Benefits

1. **Testing & Validation** - Call all tools to validate server functionality in CI/CD
2. **Live Documentation** - Include actual tool execution results in docs
3. **Debugging** - See real tool responses during development
4. **Flexibility** - Works with all output formats (markdown, html, json, pdf, hugo)

## Example Usage

**CLI:**
```bash
# Call specific tool with arguments
mcp-server-dump --call-tool="get_weather" --tool-args='{"location":"London"}' node server.js

# Call all tools for testing
mcp-server-dump --call-all-tools node server.js
```

**GitHub Action:**
```yaml
- uses: spandigital/mcp-server-dump@v1
  with:
    server-command: 'node server.js'
    call-tool: 'get_weather,get_forecast'
    tool-args: '{"location":"London","units":"metric"}'
```

## Code Quality

- ✅ All code passes `golangci-lint` with zero issues
- ✅ Formatted with `gofmt` and `gofumpt`
- ✅ YAML syntax validated
- ✅ Comprehensive error handling
- ✅ Feature parity between CLI and GitHub Action

## Testing

- Build verified successfully
- CLI flags tested and working
- GitHub Action YAML syntax validated
- Tool call results properly integrated into all output formats

## Compatibility

- ✅ Fully backward compatible - tool calling is opt-in
- ✅ Works with existing features (context files, selective scanning, Hugo format)
- ✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)