### PR TITLE
fix: Add missing template define for tool_calls

### DIFF
--- a/internal/app/templates/tool_calls.md.tmpl
+++ b/internal/app/templates/tool_calls.md.tmpl
@@ -1,4 +1,4 @@
-{{- /* Template for tool call results section */ -}}
+{{- define "tool_calls" -}}
 ## Tool Call Results
 
 {{- range .ToolCalls}}
@@ -38,3 +38,4 @@
 
 {{- end}}
 {{- end}}
+{{- end -}}


### PR DESCRIPTION
## Problem

The `tool_calls.md.tmpl` template was missing the `{{define "tool_calls"}}` wrapper, causing a template execution error when the tool calling feature was used.

### Error Message
```
template: base.md.tmpl:52:11: executing "base.md.tmpl" at 
<{{template "tool_calls" .}}>: template "tool_calls" not defined
```

## Solution

Added the proper `{{define "tool_calls"}}...{{end}}` wrapper to match the pattern used by other templates:
- `capabilities.md.tmpl` uses `{{define "capabilities"}}`
- `tools.md.tmpl` uses `{{define "tools"}}`
- `resources.md.tmpl` uses `{{define "resources"}}`
- `prompts.md.tmpl` uses `{{define "prompts"}}`

## Testing

Verified the fix works with tool calling:
```bash
./mcp-server-dump \
--transport=streamable \
--endpoint="https://eng.presidium.spandigital.io/mcp" \
-H "Authorization:Bearer token" \
--call-tool=search \
--tool-args='{"limit": 10, "query": "test"}'
```

## Impact

- **Severity**: Critical - Tool calling feature completely broken in v1.33.0
- **Type**: Bug fix (patch release)
- **Affected Version**: v1.33.0
- **Fix Version**: v1.33.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)