### PR TITLE
docs: add streamable transport examples to tool calling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ mcp-server-dump --call-all-tools node server.js
 # Call all tools with specific arguments
 mcp-server-dump --call-all-tools --tool-args='{"test":"true"}' node server.js
 
+# Call tools on a streamable HTTP transport server
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" \
+  --call-tool="search" --tool-args='{"query":"example"}'
+
+# Call tools with authentication headers
+mcp-server-dump --transport=streamable --endpoint="http://localhost:3001/stream" \
+  -H "Authorization:Bearer your-token-here" \
+  --call-all-tools
+
+# Call specific tools on remote server with custom headers
+mcp-server-dump --transport=streamable --endpoint="http://api.example.com/mcp" \
+  -H "Authorization:Bearer token123" \
+  -H "X-API-Key:key456" \
+  --call-tool="analyze_data" --tool-args='{"dataset":"production"}'
+
 # Combine tool calling with other options
 mcp-server-dump --call-tool="search" --tool-args='{"query":"example"}' -f html -o docs.html node server.js
 


### PR DESCRIPTION
## Summary
- Enhanced the Tool Calling section with examples demonstrating streamable HTTP transport usage
- Added three new examples showing tool calling with `--transport=streamable`, `--endpoint`, and `--headers` flags
- Demonstrates authentication with Bearer tokens and API keys

## Changes
- **Basic tool calling with streamable transport**: Shows how to call tools on an HTTP streamable server
- **Tool calling with authentication headers**: Demonstrates using Bearer token authentication with `--call-all-tools`
- **Multiple headers example**: Shows calling specific tools with both Authorization and X-API-Key headers

## Test plan
- [x] Verified examples follow existing documentation style
- [x] Confirmed flag syntax matches CLI implementation
- [x] Examples demonstrate practical real-world use cases for remote MCP servers

## Context
These examples help users understand how to:
- Test and document remote MCP servers over HTTP
- Use authentication headers with tool calling
- Work with MCP servers that require custom headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)