### PR TITLE
ci: pin golangci-lint to v2.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        # Pinned to avoid lint breakage when `latest` advances to a newer
+        # gosec whose findings no longer match our //nolint:gosec directives.
+        version: v2.10.1
 
   test:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ go mod download
 
 ### Linting
 ```bash
-# Install golangci-lint v2.4.0 (required for Go 1.26 support)
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+# Install golangci-lint v2.10.1 (pinned in CI; matches our //nolint:gosec directives)
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
 # Run linter (may need to use $GOPATH/bin/golangci-lint if not in PATH)
 golangci-lint run


### PR DESCRIPTION
## Summary
CI's lint job used `golangci-lint-action` with `version: latest`. Since `latest` advanced from **v2.10.1** (the version that was green on `main` as of 2026-02-23) to **v2.11.x+**, every PR's `lint` check started failing — including all open Dependabot PRs.

Root cause: the newer bundled gosec added the **G117** "marshaled struct field matches secret pattern" rule and shifted line reporting, so our existing `//nolint:gosec` directives in `internal/auth/*.go` no longer matched their findings, tripping `nolintlint`.

## Change
- Pin `version: v2.10.1` — verified locally to lint clean (`0 issues`) against the current tree.
- Update the stale `v2.4.0` reference in `CLAUDE.md` (v2.4.0 is actually too old and also fails).

## Testing
- `golangci-lint v2.10.1 run ./...` → `0 issues`
- `golangci-lint v2.12.1 run ./...` → fails (reproduces the CI breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)